### PR TITLE
vscode_setting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint", // ESLint
+    "esbenp.prettier-vscode", // Prettier
+    "yusukehirao.vscode-markuplint", // Markuplint
+    "bradlc.vscode-tailwindcss" // Tailwind CSS IntelliSense
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit", // ファイル保存時にESLintの自動修正を実行する
+    "source.addMissingImports": "explicit" // 未importのモジュールを自動で探してimport文を追加する
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode", // Prettierをフォーマッターとして設定
+  "editor.formatOnSave": true // ファイル保存時にフォーマットする
+}


### PR DESCRIPTION
## やったこと

[Next.js + TypeScript + Tailwind CSS の開発環境をできるだけ丁寧に構築する【2024年】](https://zenn.dev/yoshinoki/articles/next-ts-tailwind-setting)を参考にVScodeを便利にする設定